### PR TITLE
QFG4CD: Fix parsing/compiling escaped backslash in string literals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,6 +155,9 @@ csx/
 # Windows Store app package directory
 AppPackages/
 
+# Visual Studio dir created in newer versions
+.vs/
+
 # Others
 sql/
 *.Cache

--- a/SCICompanionLib/Src/Compile/ParserCommon.h
+++ b/SCICompanionLib/Src/Compile/ParserCommon.h
@@ -295,7 +295,7 @@ bool _ReadStringSCI(_TContext *pContext, _It &stream, std::string &str)
 		bool addedSpace = false;
 		bool lookingForSecondHex = false;
 		int chHex = 0;
-		while ((ch = *(++stream)) && ((ch != Q2) || (chPrev == '\\')))
+		while ((ch = *(++stream)) && ((ch != Q2) || fEscape))
 		{
 			chPrev = ch;
 			bool processCharNormally = true;
@@ -325,6 +325,10 @@ bool _ReadStringSCI(_TContext *pContext, _It &stream, std::string &str)
 					case '_':
 						// \_ is an underscore.
 						str += "_";
+						break;
+					case '\\':
+						// "\\" should output a single backslash, "\"
+						str += '\\';
 						break;
 					case Q2:
 						str += Q2;

--- a/SCICompanionLib/Src/MFCViews/ScriptView.cpp
+++ b/SCICompanionLib/Src/MFCViews/ScriptView.cpp
@@ -682,6 +682,24 @@ BOOL IsSCINumber(LPCTSTR pszChars, int nLength)
 	return IsStudioNumber(pszChars, nLength);
 }
 
+BOOL IsStringCharEscaped(LPCTSTR pszChars, int indexOfChar)
+{
+	BOOL isEscaped{ FALSE };
+	if (indexOfChar != 0)
+	{
+		for (int i{ indexOfChar - 1 }; i >= 0; i--)
+		{
+			if (pszChars[i] == '\\') {
+				isEscaped = !isEscaped;
+			}
+			else {
+				break;
+			}
+		}
+	}
+	return isEscaped;
+}
+
 #define DEFINE_BLOCK(pos, colorindex)	\
 	ASSERT((pos) >= 0 && (pos) <= nLength);\
 	if (pBuf != nullptr)\
@@ -818,7 +836,7 @@ DWORD CScriptView::_ParseLineSCI(DWORD dwCookie, int nLineIndex, TEXTBLOCK *pBuf
 		//	String constant "...."
 		if (dwCookie & COOKIE_STRING)
 		{
-			if (pszChars[I] == '"' && (I == 0 || pszChars[I - 1] != '\\'))
+			if (pszChars[I] == '"' && !IsStringCharEscaped(pszChars, I))
 			{
 				dwCookie &= ~COOKIE_STRING;
 				bRedefineBlock = TRUE;
@@ -829,7 +847,7 @@ DWORD CScriptView::_ParseLineSCI(DWORD dwCookie, int nLineIndex, TEXTBLOCK *pBuf
 		// Internal string {....}
 		if (dwCookie & COOKIE_INTERNALSTRING)
 		{
-			if (pszChars[I] == '}' && (I == 0 || pszChars[I - 1] != '\\'))
+			if (pszChars[I] == '}' && !IsStringCharEscaped(pszChars, I))
 			{
 				dwCookie &= ~COOKIE_INTERNALSTRING;
 				bRedefineBlock = TRUE;
@@ -840,7 +858,7 @@ DWORD CScriptView::_ParseLineSCI(DWORD dwCookie, int nLineIndex, TEXTBLOCK *pBuf
 		//	Said spec '..'
 		if (dwCookie & COOKIE_CHAR)
 		{
-			if (pszChars[I] == '\'' && (I == 0 || pszChars[I - 1] != '\\'))
+			if (pszChars[I] == '\'' && !IsStringCharEscaped(pszChars, I))
 			{
 				dwCookie &= ~COOKIE_CHAR;
 				bRedefineBlock = TRUE;

--- a/SCICompanionLib/Src/Util/AppState.cpp
+++ b/SCICompanionLib/Src/Util/AppState.cpp
@@ -853,6 +853,7 @@ char* AppState::GetAboutText()
 	return
 		"By Phil Fortier (IceFall Games)\r\n"
 		"Modified by Kawa (Firrhna Productions)\r\n"
+		"Additional contributions by Laurence Dougal Myers (https://www.laurencemyers.com.au)\r\n"
 		"\r\n"
 		"Parts of code (""Crystal Edit"" text editor) by Andrei Stcherbatchenko\r\n"
 		"Contains decompression routines from the ScummVM project.\r\n"


### PR DESCRIPTION
## Parser fix

ParserCommon.h: _ReadStringSCI: fix parsing `\\`

In QFG4CD, script 54 "Import" tries to add a backslash to a string, using the syntax `{\\}`. The parser used a naive test to see if the closing quote char was escaped, by checking if the previous character was a backslash, which falls over when _that_ backslash is escaped by another backslash. I've fixed it by instead checking the "fEscape" boolean.

I've also added an explicit case for parsing an escaped backslash. This might fix/impact the "default else" case - we may want to uncomment the statement `processCharNormally = true`, since my changes might fix the case for `sciAudio\\command.con`.

## Syntax highlighting fix

ScriptView.cpp: fix syntax highlighting for double-quoted string literals containing double-backslashes (escape characters), in SCI script syntax.

## Additional changes

- Add my name to the credits. Mostly to test that I can rebuild the project with some kind of change. :) (I don't mind removing this or making it less prominent, it was just for testing really.)
- .gitignore: ignore the `.vs/` directory, added in at least Visual Studio 2022

## Testing

### Before

- Decompile QFG4CD. (I used a copy without NewRisingSun's patches, i.e. not the GOG version.)
- Open script 54 (`MyButton_54.sc`, which is actually the hero import script)
- Scroll to line 600. Observe that all code after column 54 is syntax highlighted as if it were part of the string.
- Compile the script. Observe that you receive the error "Expected an expression."

![2023-03-28 14_11_37-SCICompanion -  MyButton_54 sc](https://user-images.githubusercontent.com/6336048/228119231-2ef40a34-1fdd-4806-8f58-29bf6389eadc.png)

![2023-03-28 14_11_59-SCICompanion -  MyButton_54 sc](https://user-images.githubusercontent.com/6336048/228119227-b0512d10-7204-4882-970f-3be2955b2e10.png)

### After

As before, but this time the syntax highlighting is constrained to the actual string literal, and compilation succeeds.

![2023-03-28 14_20_31-SCICompanion -  MyButton_54 sc](https://user-images.githubusercontent.com/6336048/228119363-46caad79-c17b-4055-8a07-3f1884f06b3a.png)

![2023-03-28 14_20_49-SCICompanion -  MyButton_54 sc](https://user-images.githubusercontent.com/6336048/228119357-bb614438-79b5-4637-b08d-ae0c2767aaa2.png)

## Other notes

In ParserCommon.h, _ReadStringSCI, there's a line of code commented out: `processCharNormally = true`. The comment near it mentions that it was causing problems parsing `sciAudio\\command.con` into `sciAudio\\mmand.con`. I think my changes fix the parsing of the double backslash, so we might be able to restore the commented code. I don't know what game/script it's referring to, so I can't test it myself.

_(However, it might be even better to just fail parsing, if we find an invalid escape sequence like `\c`. I don't know if that's possible currently.)_

## Caveats

- I've not fixed the SCI Studio syntax, I don't see much value in supporting it any more.
- I'm a C++ newbie, I may have made some basic mistakes. For example, the function signature  `BOOL IsStringCharEscaped(LPCTSTR pszChars, int indexOfChar)` might be wrong. I wasn't sure whether to use `BOOL`, like the other existing functions, or `bool`, which seems more standard. I also would have thought `LPCTSTR pszChars` should be `LPCTSTR &pszChars`. Any guidance would be welcome (but not expected). 🙂 