### PR TITLE
Fix duplicate property assignment / atop p-code.

### DIFF
--- a/SCICompanionLib/Src/Compile/Compile.cpp
+++ b/SCICompanionLib/Src/Compile/Compile.cpp
@@ -2189,7 +2189,6 @@ CodeResult Assignment::OutputByteCode(CompileContext &context) const
 			break;
 		case ResolvedToken::ClassProperty:
 			assert(pIndexer == nullptr || context.HasErrors());
-			StoreProperty(context, wIndex, false, GetLineNumber());  // false -> accumulator
 #ifdef ENABLE_LDMSTM
 			if (_variable->IsDeref)
 			{
@@ -2203,6 +2202,8 @@ CodeResult Assignment::OutputByteCode(CompileContext &context) const
 			{
 				StoreProperty(context, wIndex, false, GetLineNumber());  // false -> accumulator
 			}
+#else
+			StoreProperty(context, wIndex, false, GetLineNumber());  // false -> accumulator
 #endif
 			break;
 		}


### PR DESCRIPTION
I noticed that re-compiling a script would change `(= state newState)` into `(= (= state newState))`. Looking at the p-code, I saw that the `aTop` instruction would be duplicated.

I found it was just caused by `StoreProperty()` being called twice when `ENABLE_LDMSTM` is set. I've fixed it by moving the original call into an `#else` branch.

## Original

![2023-04-03 19_34_44-SCICompanion -  MyButton_54 sc](https://user-images.githubusercontent.com/6336048/229473813-5e82727b-ebb5-41bb-941d-393febd8fdf9.png)

![2023-04-03 19_35_04-_new 1 - Notepad++](https://user-images.githubusercontent.com/6336048/229473591-e2383c18-72fa-462d-b5e5-fc3f21618228.png)

## Duplicated

Compiling then de-compiling gives these results.

![2023-04-03 19_37_10-SCICompanion -  MyButton_54 sc](https://user-images.githubusercontent.com/6336048/229473679-00eb1c20-32c1-4aff-84ee-66dc50498128.png)

![2023-04-03 19_35_08-C__Users_L Dawg_AppData_Local_Temp_script sca txt - Notepad++](https://user-images.githubusercontent.com/6336048/229473564-78a734c3-8419-4285-8ca6-8b92accd430a.png)

