### PR TITLE
Add GitHub Actions workflow, build on push

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,14 +1,7 @@
-# Using GitHub Actions, build a C++ program targeting MS VS 2015 and the Windows 8.1 SDK
-# Use the image "windows-latest"
-# Use msbuild to build the solution
-# Target VS 2015
-# Target the Windows 8.1 SDK
-# Build the solution
-# Copy the output to the artifacts directory
+name: Build SCI Companion
 
-name: Build Windows
-
-on: [push]
+on:
+  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,6 +44,10 @@ jobs:
         msbuild SCICompanion.sln /m /p:Configuration=${{ matrix.configuration }} /p:Platform=${{ matrix.platform }} /p:VisualStudioVersion=14.0 /p:WindowsTargetPlatformVersion=8.1
         mkdir artifacts
         copy ${{ matrix.configuration }}\*.exe artifacts
+        Get-ChildItem ${{ matrix.configuration }} -Directory |
+        Foreach-Object {
+            Copy-Item -Path $_.FullName -Destination "artifacts" -recurse
+        }
 
     - name: Upload Artifacts
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,52 @@
+# Using GitHub Actions, build a C++ program targeting MS VS 2015 and the Windows 8.1 SDK
+# Use the image "windows-latest"
+# Use msbuild to build the solution
+# Target VS 2015
+# Target the Windows 8.1 SDK
+# Build the solution
+# Copy the output to the artifacts directory
+
+name: Build Windows
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    strategy:
+      matrix:
+        configuration: [Kawa]
+        platform: [Win32]
+
+    steps:
+    - uses: actions/checkout@v3
+
+    # Add msbuild action
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v1.1
+
+    # Install VS 2015 (Platform Tools v140), and Windows 8.1 SDK. See: https://stackoverflow.com/a/74673996/953887
+    - name: Install MSVC 2015 (v140) and Windows 8.1 SDK
+      shell: powershell
+      run: |
+        $VS_BTOOLS_EXE="vs_buildtools.exe"
+        $VS_BTOOLS_URI="https://aka.ms/vs/15/release/vs_buildtools.exe"
+        Invoke-WebRequest -Uri $VS_BTOOLS_URI -OutFile $VS_BTOOLS_EXE
+        Start-Process -FilePath ./vs_BuildTools.exe -ArgumentList `
+        "--add", "Microsoft.VisualStudio.Component.VC.140", `
+        "--add", "Microsoft.VisualStudio.Component.Windows81SDK", `
+        "--quiet", "--norestart", "--force", "--wait" -Wait -PassThru
+
+    # Compile the solution
+    - name: Build
+      run: |
+        msbuild SCICompanion.sln /m /p:Configuration=${{ matrix.configuration }} /p:Platform=${{ matrix.platform }} /p:VisualStudioVersion=14.0 /p:WindowsTargetPlatformVersion=8.1
+        mkdir artifacts
+        copy ${{ matrix.configuration }}\*.exe artifacts
+
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: SCICompanion-${{ matrix.configuration }}-${{ matrix.platform }}-${{ github.sha }}
+        path: artifacts

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,77 @@
+name: Nightly Build
+
+on:
+  schedule:
+    - cron: '15 7 * * *'
+
+jobs:
+  # Only execute if the current commit does _not_ have a tag that starts with "nightly/".
+  # This is intended to avoid creating a nightly build if there's no changes.
+  check-should-execute:
+    runs-on: windows-latest
+    outputs:
+      should_execute: ${{ steps.should_execute_step.outputs.should_execute }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Get tags
+        run: git fetch --tags origin
+
+      - id: should_execute_step
+        shell: bash
+        run: |
+          git tag --points-at ${{ github.sha }}
+          if [ $(git tag --list nightly/* --points-at HEAD) ]; then
+            echo "Nightly tag found, skipping build."
+          else
+            echo "No nightly tag found, building."
+            echo "should_execute=true" >> $GITHUB_OUTPUT
+          fi
+
+  build:
+    needs: check-should-execute
+    if: ${{ needs.check-should-execute.outputs.should_execute }}
+    uses: ./.github/workflows/build.yaml
+
+  create-nightly-release:
+    runs-on: windows-latest
+
+    needs: [check-should-execute, build]
+    if: ${{ needs.check-should-execute.outputs.should_execute }}
+
+    permissions:
+      contents: write
+
+    steps:
+    - name: Download artifacts
+      uses: actions/download-artifact@v3
+      with:
+        path: release-artifacts/
+
+    - name: Get the current date (UTC)
+      id: get-date
+      shell: bash
+      run: |
+        echo "nightly_date=$(date -u +%Y-%m-%d)" >> $GITHUB_OUTPUT
+    
+    # actions/download-artifact will unzip each artifact to its own directory, so we need to re-zip them.
+    # We'll also replace the commit SHA with the date in the zip file name.
+    - name: Re-zip each artifact
+      shell: powershell
+      run: |
+        Get-ChildItem release-artifacts -Directory |
+        Foreach-Object {
+            Compress-Archive -Path $_.FullName -DestinationPath ("release-artifacts/" + ($_ -replace "[0-9a-z]{40}","${{ steps.get-date.outputs.nightly_date }}") + ".zip")
+        }
+
+    - name: Create a release
+      uses: ncipollo/release-action@v1
+      with:
+        artifactErrorsFailBuild: true
+        artifacts: "release-artifacts/*.zip"
+        commit: ${{ github.sha }}
+        generateReleaseNotes: true
+        name: Nightly build for ${{ steps.get-date.outputs.nightly_date }} 
+        prerelease: true
+        skipIfReleaseExists: true
+        tag: nightly/${{ steps.get-date.outputs.nightly_date }}

--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -1,0 +1,7 @@
+name: Build On Push
+
+on: [push]
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yaml


### PR DESCRIPTION
I was thinking it'd be nice to have some automated regression tests. It could let us make future changes with confidence. As a first step, I've set up a GitHub Actions workflow, which builds SCICompanion.exe.

Here's an example run:

https://github.com/laurence-myers/SCICompanion/actions/runs/4602703641

The produced artifact zip is named like `SCICompanion-${{ matrix.configuration }}-${{ matrix.platform }}-${{ github.sha }}`. It contains the compiled `SCICompanion.exe`, and any sub-directories included in the build (e.g. `include`, the template projects, DOSBox, etc). Artifacts only live for 90 days, so you would probably want to create a "Release" in GitHub for anything you want to keep.

Currently, it only builds the "Kawa" configuration targeting the "Win32" platform. I've defined these in a [matrix](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs), so we can easily create builds for "Release" and/or "x64", and any combination of config/platform.

It currently runs on every push to every branch.

It looks like builds take 11-15 minutes to run.

Note that the GitHub Windows runner doesn't include MSVC 2015 (platform tools v140), nor Windows 8.1 SDK, so they have to be manually downloaded and installed. If we can update the project to use a newer MSVC (Visual Studio 2022 or 2019) and target Windows 10 SDK, then we could save ~5 minutes on the build (since the runner already includes them).

## Example

### Workflow

![2023-04-04 11_07_43-GitHub Actions_ include all non-compiled resources in the build artif… · laurenc](https://user-images.githubusercontent.com/6336048/229660163-cb64f766-eb63-4d27-9c00-b9c2dfee13b8.png)

### Job

![2023-04-04 11_07_59-GitHub Actions_ include all non-compiled resources in the build artif… · laurenc](https://user-images.githubusercontent.com/6336048/229660159-beb22b33-f955-4145-8eef-0ea023ff91e8.png)

### Artifact contents

![2023-04-04 11_09_12-SCICompanion-Kawa-Win32-921c75721abe5f8e65d23d4c544bf458637c070f zip](https://user-images.githubusercontent.com/6336048/229660302-7abfe3d0-d906-49ed-aa10-3dde3964ac30.png)
