### PR TITLE
add JASC-PAL support when importing palettes

### DIFF
--- a/SCICompanionLib/Src/Dialogs/PaletteDefinitionDialog.cpp
+++ b/SCICompanionLib/Src/Dialogs/PaletteDefinitionDialog.cpp
@@ -255,7 +255,7 @@ void CPaletteDefinitionDialog::OnColorClick(BYTE bIndex, int nID, BOOL fLeftClic
 
 bool _GetPaletteFilename(bool open, const std::string &dialogTitle, std::string &filename)
 {
-	CFileDialog fileDialog(open, ".pal", nullptr, OFN_NOCHANGEDIR, "PAL files (*.pal)|*.pal|All Files|*.*|");
+	CFileDialog fileDialog(open, ".pal", nullptr, OFN_NOCHANGEDIR, "PAL files (*.pal)|*.pal|PspPalette files (*.PspPalette)|*.PspPalette|All Files|*.*|");
 	fileDialog.m_ofn.lpstrTitle = dialogTitle.c_str();;
 	if (IDOK == fileDialog.DoModal())
 	{


### PR DESCRIPTION
## Overview
Add `JASC-PAL` support when importing palettes.

Currently, only `RIFF-PAL` palettes are supported. These are binary files and difficult for human reading. `JASC-PAL` are palette files that are human readable.

They have the following format according to [this source](https://liero.nl/lierohack/docformats/other-jasc.html):
>This file works like this: The PAL file is a text file, so NO binary data.
The first line of data contains the text `JASC-PAL`.
The second line contains the text `0100`--can skip over.
The third line contains a number. This is the number of colors in the palette, most likely 256 colors.
>After that, there are lines of text, containing 3 numbers per line, with spaces between them.
These numbers are respectively the Red, Green and Blue values (the so-called RGB palette). For example, the color white would be '255 255 255' and black '0 0 0' (255 is the most bright, 0 the less bright)