### PR TITLE
Bug Fixes: Animate View dialog "background" button position update on resize + use resampled audio

### DIFF
--- a/SCICompanionLib/Src/Dialogs/AnimateDialog.cpp
+++ b/SCICompanionLib/Src/Dialogs/AnimateDialog.cpp
@@ -134,7 +134,7 @@ void CAnimateDialog::OnSize(UINT nType, int cx, int cy)
 			rectAnimateScreen.bottom = rectAnimateScreen.top + rectAnimateScreen.Height() + dy;
 			m_wndAnimate.MoveWindow(&rectAnimateScreen, TRUE);
 
-			int rgid[] = { IDOK, IDC_BUTTONPLAY };
+			int rgid[] = { IDOK, IDC_BUTTONBG, IDC_BUTTONPLAY };
 			for (int i = 0; i < ARRAYSIZE(rgid); i++)
 			{
 				CWnd *pOk = GetDlgItem(rgid[i]);

--- a/SCICompanionLib/Src/Util/SoundUtil.cpp
+++ b/SCICompanionLib/Src/Util/SoundUtil.cpp
@@ -248,7 +248,7 @@ void AudioComponentFromWaveFile(sci::istream &stream, AudioComponent &audio, Aud
 		audio.DigitalSamplePCM.assign(samplesWritten * convertedSampleSize, 0);
 		for (int i = 0; i < samplesWritten; i++)
 		{
-			double f = fpData[i];
+			double f = results[i];
 			uint16_t value;
 			if (convertedSampleSize == 2)
 			{


### PR DESCRIPTION
Two small bug fixes. I built and tested the changes locally.

## Bug Fix: Animated View "background" button not updating on window resize

The "background" button was not moving dynamically when resizing the "Animate" dialog for viewing a View animation.

The background button was missing from the Animate dialog button update array.

### SCICompanion/SCICompanionLib/Src/Dialogs/AnimateDialog.cpp - Line 137

Old: `int rgid[] = { IDOK, IDC_BUTTONPLAY };`
New: `int rgid[] = { IDOK, IDC_BUTTONBG, IDC_BUTTONPLAY };`

## Bug Fix: Resampled audio not used

When importing an audio clip above 22050hz for a Message, the resulting audio was stretched and cut short.

It appears that the original audio data was being returned instead of the resampled audio.

### SCICompanion/SCICompanionLib/Src/Util/SoundUtil.cpp - Line 251

Old: `double f= fpData[i];`
New: `double f = results[i];`