### PR TITLE
Fix initial values for inherited instance properties; Update GitHub Actions versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,11 +13,11 @@ jobs:
         platform: [Win32]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     # Add msbuild action
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1.1
+      uses: microsoft/setup-msbuild@v2
 
     # Install VS 2015 (Platform Tools v140), and Windows 8.1 SDK. See: https://stackoverflow.com/a/74673996/953887
     - name: Install MSVC 2015 (v140) and Windows 8.1 SDK
@@ -43,7 +43,7 @@ jobs:
         }
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: SCICompanion-${{ matrix.configuration }}-${{ matrix.platform }}-${{ github.sha }}
         path: artifacts

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -12,7 +12,7 @@ jobs:
     outputs:
       should_execute: ${{ steps.should_execute_step.outputs.should_execute }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Get tags
         run: git fetch --tags origin
@@ -44,7 +44,7 @@ jobs:
 
     steps:
     - name: Download artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         path: release-artifacts/
 

--- a/SCICompanionLib/Src/Compile/SCO.h
+++ b/SCICompanionLib/Src/Compile/SCO.h
@@ -72,7 +72,7 @@ public:
 private:
 	WORD _wNameIndex;
 	WORD _wValue;
-	bool _fNeedsReloc;
+	bool _fNeedsReloc { false };
 };
 
 class CSCOObjectClass


### PR DESCRIPTION
# Fix initial values for inherited instance properties

I observed that compiling a script in Quest for Glory 2, or The Castle of Dr Brain, would often cause an "Oops!" error in-game. I also found some odd behaviour, such as the background pic would be drawn mirrored horizontally. Decompiling the script into bytecode, I could see that the crashes occurred when inherited instance properties all were set to to some arbitrary value, and no crash occurs when the value is `0`.

I stepped through the code in `GenerateScriptResource.cpp`. In [`GenerateScriptResource_SCI0`](https://github.com/Kawa-oneechan/SCICompanion/blob/4314c86670134a31ee07725c2dcedf7e8b59659b/SCICompanionLib/Src/Compile/GenerateScriptResource.cpp#L1231), I could see the values in the `output` array looked correct (the values for instance properties were set to `0`), until it invoked `context.FixupSinksAndSources()`, after which the values were changed. These new values matched the arbitrary values I saw in the decompiled bytecode.

I noticed that [`CSCOObjectProperty` has two constructors](https://github.com/Kawa-oneechan/SCICompanion/blob/4314c86670134a31ee07725c2dcedf7e8b59659b/SCICompanionLib/Src/Compile/SCO.h#L60). One does not have an initializer list, which means the instance fields are initialized with arbitrary values. This meant that [`_fNeedsReloc`](https://github.com/Kawa-oneechan/SCICompanion/blob/4314c86670134a31ee07725c2dcedf7e8b59659b/SCICompanionLib/Src/Compile/SCO.h#L75) would always have an arbitrary value (due to not being explicitly initialized), which would often be non-zero (i.e. true), which would cause the object properties to always require relocation. I believe this is what causes the corrupted inherited instance property values.

I added a member initializer to `_fNeedsReloc`, defaulting it to `false`. I tried compiling a test script a few times, and every time the disassembly showed that instance properties were inherited correctly. They weren't just `0`; e.g. a `Rm` instance would have a default property value `vanishingY $8ad0`.

Notes:

- I don't know enough C++ to know how the new "member initializer" interacts with the existing constructor that uses an "initializer list". Will the "member initializer" override the value passed in to the constructor as `fTrackRelocation `?
- There are other private members that aren't initialized: `_wNameIndex` and `_wValue`. Should they be given a value, or set to `NULL` (yuck)?
- There are [other classes with similar uninitialized members](https://github.com/Kawa-oneechan/SCICompanion/blob/4314c86670134a31ee07725c2dcedf7e8b59659b/SCICompanionLib/Src/Compile/SCO.h#L38). E.g. [CSCOPublicExport._strName](https://github.com/Kawa-oneechan/SCICompanion/blob/4314c86670134a31ee07725c2dcedf7e8b59659b/SCICompanionLib/Src/Compile/SCO.h#L41). Is this an issue?


<details>
<summary><h2>Before fix</h2></summary>

### Debugger - output before relocations

![Screenshot 2025-04-13 233332](https://github.com/user-attachments/assets/83d2c0da-1c83-47c1-9079-ef63525876c7)

### Debugger - output after relocations

![Screenshot 2025-04-13 233339](https://github.com/user-attachments/assets/a102ee47-c4b5-4eb1-a4bc-24c84171d6a9)

### Disassembled bytecode

![Screenshot 2025-04-13 233358](https://github.com/user-attachments/assets/953a02e0-144d-42e9-92d5-3dc50cfeef6e)

</details>

<details>
<summary><h2>After fix</h2></summary>

### Debugger - output before relocations

![Screenshot 2025-04-13 233813](https://github.com/user-attachments/assets/68fb7179-2c0a-4b81-82bd-0465fe2064fd)

### Debugger - output after relocations

![Screenshot 2025-04-13 233820](https://github.com/user-attachments/assets/d09d2a35-4b77-4c05-8610-ae78aaf986ec)

### Disassembled bytecode

![Screenshot 2025-04-13 233837](https://github.com/user-attachments/assets/8033428a-6964-4141-96f3-10c44b65f67d)

</details>

Fixes #30 

---

# Update GitHub Actions versions

I noticed that GitHub Actions was failing due to unsupported action versions, I've updated everything, fingers crossed it "just works".