### PR TITLE
Upgrade solution to VS2022, set platform to V143 and set compiler to C++17

### DIFF
--- a/Prof-UIS.2.92/ProfUISLIB/ProfUISLIB_1000.vcxproj
+++ b/Prof-UIS.2.92/ProfUISLIB/ProfUISLIB_1000.vcxproj
@@ -107,7 +107,7 @@
     <ProjectGUID>{89CFFC49-D858-481E-99C5-E312F7C1EA95}</ProjectGUID>
     <RootNamespace>ProfUISLIB</RootNamespace>
     <Keyword>MFCProj</Keyword>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -120,143 +120,143 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>Dynamic</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Static MBCS Debug RDE|Win32'">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>Static</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Static Unicode Release with MFC DLL|Win32'">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>Dynamic</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Static MBCS Debug RDE with MFC DLL|Win32'">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>Dynamic</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Static Unicode Release|Win32'">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>Static</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Static Unicode Release RDE with MFC DLL|Win32'">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>Dynamic</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Static Unicode Debug RDE|Win32'">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>Static</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Static MBCS Debug with MFC DLL|Win32'">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>Dynamic</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Static ANSI Debug with MFC DLL|Win32'">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>Dynamic</UseOfMfc>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Static MBCS Release|Win32'">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>Static</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Static ANSI Debug RDE with MFC DLL|Win32'">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>Dynamic</UseOfMfc>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Static ANSI Debug RDE|Win32'">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>Static</UseOfMfc>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Static Unicode Debug with MFC DLL|Win32'">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>Dynamic</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Static ANSI Release RDE|Win32'">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>Static</UseOfMfc>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Static ANSI Release with MFC DLL|Win32'">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>Dynamic</UseOfMfc>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Static MBCS Debug|Win32'">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>Static</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DeadCodeAnalysis|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>Static</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Static MBCS Release RDE with MFC DLL|Win32'">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>Dynamic</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Static Unicode Release RDE|Win32'">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>Static</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Static ANSI Release RDE with MFC DLL|Win32'">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>Dynamic</UseOfMfc>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Static MBCS Release with MFC DLL|Win32'">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>Dynamic</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Static ANSI Release|Win32'">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>Static</UseOfMfc>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Static Unicode Debug|Win32'">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>Static</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Static ANSI Debug|Win32'">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>Static</UseOfMfc>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Static MBCS Release RDE|Win32'">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>Static</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/SCICompanion/SCICompanion.vcxproj
+++ b/SCICompanion/SCICompanion.vcxproj
@@ -22,19 +22,20 @@
     <ProjectGuid>{6F805ECA-9DC8-42E0-A918-38A7315C7E8F}</ProjectGuid>
     <RootNamespace>SCICompanion</RootNamespace>
     <Keyword>MFCProj</Keyword>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <UseOfMfc>Static</UseOfMfc>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
     <UseOfMfc>Static</UseOfMfc>
@@ -42,7 +43,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Mild|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
     <UseOfMfc>Static</UseOfMfc>
@@ -50,7 +51,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Kawa|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
     <UseOfMfc>Static</UseOfMfc>
@@ -91,6 +92,7 @@
       <PreprocessorDefinitions>WIN32;_WINDOWS;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)SCICompanionLib\;$(SolutionDir)Prof-UIS.2.92\Include;$(SolutionDir)SCICompanionLib\Src\Util;$(SolutionDir)SCICompanionLib\Src\Resources;$(SolutionDir)SCICompanionLib\Src\MFCViews;$(SolutionDir)SCICompanionLib\Src\MFCFrames;$(SolutionDir)SCICompanionLib\Src\MFCDocuments;$(SolutionDir)SCICompanionLib\Src\FrameComponents;$(SolutionDir)SCICompanionLib\Src\Dialogs;$(SolutionDir)SCICompanionLib\Src\CrystalEdit;$(SolutionDir)SCICompanionLib\Src\CRC32;$(SolutionDir)SCICompanionLib\Src\CppFormat;$(SolutionDir)SCICompanionLib\Src\Compile;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -136,6 +138,7 @@ xcopy /S /Y /I /D "$(ProjectDir)Tools" "$(OutDir)Tools"</Command>
       <PreprocessorDefinitions>WIN32;_WINDOWS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)SCICompanionLib\;$(SolutionDir)Prof-UIS.2.92\Include;$(SolutionDir)SCICompanionLib\Src\Util;$(SolutionDir)SCICompanionLib\Src\Resources;$(SolutionDir)SCICompanionLib\Src\MFCViews;$(SolutionDir)SCICompanionLib\Src\MFCFrames;$(SolutionDir)SCICompanionLib\Src\MFCDocuments;$(SolutionDir)SCICompanionLib\Src\FrameComponents;$(SolutionDir)SCICompanionLib\Src\Dialogs;$(SolutionDir)SCICompanionLib\Src\CrystalEdit;$(SolutionDir)SCICompanionLib\Src\CRC32;$(SolutionDir)SCICompanionLib\Src\CppFormat;$(SolutionDir)SCICompanionLib\Src\Compile;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -184,6 +187,7 @@ xcopy /S /Y /I /D "$(ProjectDir)Tools" "$(OutDir)Tools"</Command>
       <PreprocessorDefinitions>WIN32;_WINDOWS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)SCICompanionLib\;$(SolutionDir)Prof-UIS.2.92\Include;$(SolutionDir)SCICompanionLib\Src\Util;$(SolutionDir)SCICompanionLib\Src\Resources;$(SolutionDir)SCICompanionLib\Src\MFCViews;$(SolutionDir)SCICompanionLib\Src\MFCFrames;$(SolutionDir)SCICompanionLib\Src\MFCDocuments;$(SolutionDir)SCICompanionLib\Src\FrameComponents;$(SolutionDir)SCICompanionLib\Src\Dialogs;$(SolutionDir)SCICompanionLib\Src\CrystalEdit;$(SolutionDir)SCICompanionLib\Src\CRC32;$(SolutionDir)SCICompanionLib\Src\CppFormat;$(SolutionDir)SCICompanionLib\Src\Compile;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -232,6 +236,7 @@ xcopy /S /Y /I /D "$(ProjectDir)Tools" "$(OutDir)Tools"</Command>
       <PreprocessorDefinitions>NO_WARN_MBCS_MFC_DEPRECATION;WIN32;_WINDOWS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)SCICompanionLib\;$(SolutionDir)Prof-UIS.2.92\Include;$(SolutionDir)SCICompanionLib\Src\Util;$(SolutionDir)SCICompanionLib\Src\Resources;$(SolutionDir)SCICompanionLib\Src\MFCViews;$(SolutionDir)SCICompanionLib\Src\MFCFrames;$(SolutionDir)SCICompanionLib\Src\MFCDocuments;$(SolutionDir)SCICompanionLib\Src\FrameComponents;$(SolutionDir)SCICompanionLib\Src\Dialogs;$(SolutionDir)SCICompanionLib\Src\CrystalEdit;$(SolutionDir)SCICompanionLib\Src\CRC32;$(SolutionDir)SCICompanionLib\Src\CppFormat;$(SolutionDir)SCICompanionLib\Src\Compile;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/SCICompanionLib/SCICompanionLib.vcxproj
+++ b/SCICompanionLib/SCICompanionLib.vcxproj
@@ -22,19 +22,20 @@
     <ProjectGuid>{761DE01C-57F6-45C5-AAFC-AC48000C423F}</ProjectGuid>
     <RootNamespace>SCICompanionLib</RootNamespace>
     <Keyword>MFCDLLProj</Keyword>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <UseOfMfc>Static</UseOfMfc>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>false</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
     <UseOfMfc>Static</UseOfMfc>
@@ -42,7 +43,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Kawa|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>false</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
     <UseOfMfc>Static</UseOfMfc>
@@ -50,7 +51,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Mild|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>false</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
     <UseOfMfc>Static</UseOfMfc>
@@ -92,12 +93,13 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_WINDOWS;NO_WARN_MBCS_MFC_DEPRECATION;_DEBUG;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING;WIN32;_WINDOWS;NO_WARN_MBCS_MFC_DEPRECATION;_DEBUG;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)SCICompanionLib\;$(SolutionDir)SCICompanionLib\Src\Util;$(SolutionDir)SCICompanionLib\Src\Resources;$(SolutionDir)SCICompanionLib\Src\Docs;$(SolutionDir)SCICompanionLib\Src\GIFLIB;$(SolutionDir)SCICompanionLib\Src\MFCViews;$(SolutionDir)SCICompanionLib\Src\MFCFrames;$(SolutionDir)SCICompanionLib\Src\MFCDocuments;$(SolutionDir)SCICompanionLib\Src\FrameComponents;$(SolutionDir)SCICompanionLib\Src\Dialogs;$(SolutionDir)SCICompanionLib\Src\CrystalEdit;$(SolutionDir)SCICompanionLib\Src\CRC32;$(SolutionDir)SCICompanionLib\Src\r8brain;$(SolutionDir)SCICompanionLib\Src\LipSync;$(SolutionDir)SCICompanionLib\Src\CppFormat;$(SolutionDir)SCICompanionLib\Src\Compile;$(SolutionDir)Prof-UIS.2.92\Include;$(SolutionDir)Prof-UIS.2.92\Src;$(SolutionDir)SCICompanionLib\Src\cpptoml;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/Qpar %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>false</MultiProcessorCompilation>
       <MinimalRebuild>true</MinimalRebuild>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -131,12 +133,13 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;_WINDOWS;NO_WARN_MBCS_MFC_DEPRECATION;NDEBUG;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING;WIN32;_WINDOWS;NO_WARN_MBCS_MFC_DEPRECATION;NDEBUG;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)SCICompanionLib\;$(SolutionDir)SCICompanionLib\Src\Util;$(SolutionDir)SCICompanionLib\Src\Resources;$(SolutionDir)SCICompanionLib\Src\Docs;$(SolutionDir)SCICompanionLib\Src\GIFLIB;$(SolutionDir)SCICompanionLib\Src\MFCViews;$(SolutionDir)SCICompanionLib\Src\MFCFrames;$(SolutionDir)SCICompanionLib\Src\MFCDocuments;$(SolutionDir)SCICompanionLib\Src\FrameComponents;$(SolutionDir)SCICompanionLib\Src\Dialogs;$(SolutionDir)SCICompanionLib\Src\CrystalEdit;$(SolutionDir)SCICompanionLib\Src\CRC32;$(SolutionDir)SCICompanionLib\Src\r8brain;$(SolutionDir)SCICompanionLib\Src\LipSync;$(SolutionDir)SCICompanionLib\Src\CppFormat;$(SolutionDir)SCICompanionLib\Src\Compile;$(SolutionDir)Prof-UIS.2.92\Include;$(SolutionDir)Prof-UIS.2.92\Src;$(SolutionDir)SCICompanionLib\Src\cpptoml;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/Qpar %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>false</MultiProcessorCompilation>
       <MinimalRebuild>true</MinimalRebuild>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -172,12 +175,13 @@
       <Optimization>MinSpace</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>ENABLE_UNUSEDINSTANCEWARNINGS;ENABLE_LDMSTM;ENABLE_VERBS;ENABLE_FOREACH;ENABLE_EXISTS;DISABLE_STUDIO;DISABLE_DEBUGSTUFF;ENABLE_GETPOLY;DISABLE_TRANSPARENCYNAG;ENABLE_FONTNUMSINHEX;DISABLE_FONTLIMIT;ENABLE_MOREVOCABPREVIEWS;ENABLE_DISPLAYMASSAGE;WIN32;_WINDOWS;NO_WARN_MBCS_MFC_DEPRECATION;NDEBUG;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING;ENABLE_UNUSEDINSTANCEWARNINGS;ENABLE_LDMSTM;ENABLE_VERBS;ENABLE_FOREACH;ENABLE_EXISTS;DISABLE_STUDIO;DISABLE_DEBUGSTUFF;ENABLE_GETPOLY;DISABLE_TRANSPARENCYNAG;ENABLE_FONTNUMSINHEX;DISABLE_FONTLIMIT;ENABLE_MOREVOCABPREVIEWS;ENABLE_DISPLAYMASSAGE;WIN32;_WINDOWS;NO_WARN_MBCS_MFC_DEPRECATION;NDEBUG;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)SCICompanionLib\;$(SolutionDir)SCICompanionLib\Src\Util;$(SolutionDir)SCICompanionLib\Src\Resources;$(SolutionDir)SCICompanionLib\Src\Docs;$(SolutionDir)SCICompanionLib\Src\GIFLIB;$(SolutionDir)SCICompanionLib\Src\MFCViews;$(SolutionDir)SCICompanionLib\Src\MFCFrames;$(SolutionDir)SCICompanionLib\Src\MFCDocuments;$(SolutionDir)SCICompanionLib\Src\FrameComponents;$(SolutionDir)SCICompanionLib\Src\Dialogs;$(SolutionDir)SCICompanionLib\Src\CrystalEdit;$(SolutionDir)SCICompanionLib\Src\CRC32;$(SolutionDir)SCICompanionLib\Src\r8brain;$(SolutionDir)SCICompanionLib\Src\LipSync;$(SolutionDir)SCICompanionLib\Src\CppFormat;$(SolutionDir)SCICompanionLib\Src\Compile;$(SolutionDir)Prof-UIS.2.92\Include;$(SolutionDir)Prof-UIS.2.92\Src;$(SolutionDir)SCICompanionLib\Src\cpptoml;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/Qpar %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>false</MultiProcessorCompilation>
       <MinimalRebuild>true</MinimalRebuild>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -214,13 +218,14 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>ENABLE_UNUSEDINSTANCEWARNINGS;ENABLE_MOREVOCABPREVIEWS;ENABLE_DISPLAYMASSAGE;WIN32;_WINDOWS;NO_WARN_MBCS_MFC_DEPRECATION;NDEBUG;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING;ENABLE_UNUSEDINSTANCEWARNINGS;ENABLE_MOREVOCABPREVIEWS;ENABLE_DISPLAYMASSAGE;WIN32;_WINDOWS;NO_WARN_MBCS_MFC_DEPRECATION;NDEBUG;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)SCICompanionLib\;$(SolutionDir)SCICompanionLib\Src\Util;$(SolutionDir)SCICompanionLib\Src\Resources;$(SolutionDir)SCICompanionLib\Src\Docs;$(SolutionDir)SCICompanionLib\Src\GIFLIB;$(SolutionDir)SCICompanionLib\Src\MFCViews;$(SolutionDir)SCICompanionLib\Src\MFCFrames;$(SolutionDir)SCICompanionLib\Src\MFCDocuments;$(SolutionDir)SCICompanionLib\Src\FrameComponents;$(SolutionDir)SCICompanionLib\Src\Dialogs;$(SolutionDir)SCICompanionLib\Src\CrystalEdit;$(SolutionDir)SCICompanionLib\Src\CRC32;$(SolutionDir)SCICompanionLib\Src\r8brain;$(SolutionDir)SCICompanionLib\Src\LipSync;$(SolutionDir)SCICompanionLib\Src\CppFormat;$(SolutionDir)SCICompanionLib\Src\Compile;$(SolutionDir)Prof-UIS.2.92\Include;$(SolutionDir)Prof-UIS.2.92\Src;$(SolutionDir)SCICompanionLib\Src\cpptoml;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/Qpar %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>false</MultiProcessorCompilation>
       <MinimalRebuild>true</MinimalRebuild>
       <StringPooling>true</StringPooling>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/SCICompanionLib/Src/Compile/Compile.cpp
+++ b/SCICompanionLib/Src/Compile/Compile.cpp
@@ -179,7 +179,7 @@ WORD PushToStackIfAppropriate(CompileContext &context, int lineNumber)
 	return wBytes;
 }
 
-class PerformPreScan : public std::binary_function<IOutputByteCode*, CompileContext, void>
+class PerformPreScan /* blackstar : public std::binary_function<IOutputByteCode*, CompileContext, void> */
 {
 public:
 	PerformPreScan(CompileContext &context) : _context(context) {}

--- a/SCICompanionLib/Src/Compile/CompileContext.cpp
+++ b/SCICompanionLib/Src/Compile/CompileContext.cpp
@@ -249,7 +249,7 @@ bool CompileContext::LookupDefine(const std::string &str, WORD &wValue)
 	}
 	else
 	{
-		std::unordered_map<std::string, DefinePtr>::const_iterator nodeIt = _localDefines.find(str);
+		std::map<std::string, DefinePtr>::const_iterator nodeIt = _localDefines.find(str);
 		fRet = (nodeIt != _localDefines.end());
 		if (fRet)
 		{

--- a/SCICompanionLib/Src/Compile/CompileContext.h
+++ b/SCICompanionLib/Src/Compile/CompileContext.h
@@ -59,7 +59,7 @@ class SCIClassBrowser;
 class ISourceCodePosition;
 class CompileContext;
 
-typedef std::unordered_map<std::string, sci::Define*> defines_map;
+typedef std::map<std::string, sci::Define*> defines_map;
 typedef std::multimap<std::string, code_pos> ref_multimap;
 typedef std::pair<code_pos, WORD> call_pair;
 
@@ -93,8 +93,8 @@ public:
 
 	bool LookupDefine(const std::string &str, WORD &wValue);
 private:
-	typedef std::unordered_map<std::string, sci::Define*> defines_map;
-	typedef std::unordered_map<std::string, std::unique_ptr<sci::Script>> header_map;
+	typedef std::map<std::string, sci::Define*> defines_map;
+	typedef std::map<std::string, std::unique_ptr<sci::Script>> header_map;
 
 	// Filename (not full path) which maps a header to its Script object.
 	header_map _allHeaders;
@@ -395,7 +395,7 @@ private:
 };
 
 template<typename T>
-class GenericOutputByteCode2 : public std::unary_function<std::unique_ptr<T>, void>
+class GenericOutputByteCode2
 {
 public:
 	GenericOutputByteCode2(CompileContext &context) : _context(context) {}
@@ -438,7 +438,7 @@ private:
 };
 
 
-class GenericOutputByteCode : public std::unary_function<IOutputByteCode*, void>
+class GenericOutputByteCode
 {
 public:
 	GenericOutputByteCode(CompileContext &context) : _context(context) {}

--- a/SCICompanionLib/Src/Compile/GenerateScriptResource.cpp
+++ b/SCICompanionLib/Src/Compile/GenerateScriptResource.cpp
@@ -132,7 +132,7 @@ typedef struct
 
 typedef std::vector<species_property> property_vector;
 
-struct MatchSelector : public std::binary_function<species_property, WORD, bool>
+struct MatchSelector /* blackstar : public std::binary_function<species_property, WORD, bool> */
 {
 	bool operator()(const species_property &prop, WORD wSelector) const
 	{
@@ -1125,7 +1125,14 @@ void GenerateSCOObjects(CompileContext &context, const Script &script)
 			// same script. we could filter if they are in different scripts, but sierra didn't.
 			bool fTrackRelocation = (iIndex == nameIndex) || speciesProp.fTrackRelocation;
 
-			property_vector::const_iterator overriddenIt = find_if(newProps.begin(), newProps.end(), bind2nd(MatchSelector(), speciesProp.wSelector));
+			auto overriddenIt = std::find_if(
+				newProps.begin(),
+				newProps.end(),
+				[&](const auto& prop)
+				{
+					return MatchSelector()(prop, speciesProp.wSelector);
+				});
+
 			if (overriddenIt != newProps.end())
 			{
 				wValue = overriddenIt->wValue;
@@ -1139,7 +1146,15 @@ void GenerateSCOObjects(CompileContext &context, const Script &script)
 		for (species_property &newProp : newProps)
 		{
 			// Is this a new property, not defined by the superclass?
-			property_vector::const_iterator speciesIt = find_if(speciesProps.begin(), speciesProps.end(), bind2nd(MatchSelector(), newProp.wSelector));
+
+			auto speciesIt = std::find_if(
+				speciesProps.begin(),
+				speciesProps.end(),
+				[&](const auto& prop)
+				{
+					return MatchSelector()(prop, newProp.wSelector);
+				});
+
 			if (speciesIt == speciesProps.end())
 			{
 				// Must be - we didn't find it in the species props.

--- a/SCICompanionLib/Src/Compile/SCO.cpp
+++ b/SCICompanionLib/Src/Compile/SCO.cpp
@@ -60,7 +60,7 @@ using namespace sci;
 // Handy functors
 //
 template<typename _T>
-struct FwdSave : unary_function<_T, void>
+struct FwdSave /* blackstar : unary_function<_T, void> */
 {
 public:
 	FwdSave(vector<BYTE> &output) : _output(output) {}

--- a/SCICompanionLib/Src/Compile/ScriptOMTraverse.cpp
+++ b/SCICompanionLib/Src/Compile/ScriptOMTraverse.cpp
@@ -17,7 +17,7 @@
 using namespace sci;
 using namespace std;
 
-class PerformTraverse : public std::unary_function<SyntaxNode*, void>
+class PerformTraverse /* : blackstar public std::unary_function<SyntaxNode*, void> */
 {
 public:
 	PerformTraverse(IExploreNode &en) : _en(en) {}
@@ -55,7 +55,7 @@ void ForwardTraverse2(const vector<unique_ptr<T>> &container, IExploreNode &en)
 }
 
 
-class PerformTraverse3 : public std::unary_function<SyntaxNode*, void>
+class PerformTraverse3 /* blackstar : public std::unary_function<SyntaxNode*, void> */
 {
 public:
 	PerformTraverse3(IExploreNode &en) : _en(en) {}

--- a/SCICompanionLib/Src/Compile/scii.cpp
+++ b/SCICompanionLib/Src/Compile/scii.cpp
@@ -519,7 +519,10 @@ uint16_t scicode::calc_size()
 		}
 		if (fNeedToRedo)
 		{
-			for_each(_code.begin(), _code.end(), std::mem_fun_ref(&scii::reset_size));
+			for (auto& code : _code)
+			{
+				code.reset_size();
+			}
 		}
 	} while (fNeedToRedo);
 
@@ -875,5 +878,8 @@ bool scii::_is_label_instruction()
 // We use the node pointer as a < comparator.  Just something consistent but meaningless.
 bool operator<(const code_pos &_Right, const code_pos &_Left)
 {
-	return _Right._Mynode() < _Left._Mynode();
+	// blackstar
+	// return _Right._Mynode() < _Left._Mynode();
+
+	return true;
 }

--- a/SCICompanionLib/Src/Compile/scii.cpp
+++ b/SCICompanionLib/Src/Compile/scii.cpp
@@ -876,10 +876,19 @@ bool scii::_is_label_instruction()
 
 // This craziness is so that code_pos can be used in a multimap.
 // We use the node pointer as a < comparator.  Just something consistent but meaningless.
-bool operator<(const code_pos &_Right, const code_pos &_Left)
-{
-	// blackstar
-	// return _Right._Mynode() < _Left._Mynode();
 
-	return true;
+//typedef std::list<scii>::iterator code_pos;
+//bool operator<(const code_pos &_Right, const code_pos &_Left)
+//{
+//	return _Right._Mynode() < _Left._Mynode();
+//}
+/* blackstar suggestion: use something different than std::list */
+bool operator < (const code_pos& lhs, const code_pos& rhs)
+{
+	auto it = lhs;
+	while (it != rhs && it != std::list<scii>::iterator{})
+	{
+		++it;
+	}
+	return it == rhs;
 }

--- a/SCICompanionLib/Src/Compile/scii.cpp
+++ b/SCICompanionLib/Src/Compile/scii.cpp
@@ -877,18 +877,18 @@ bool scii::_is_label_instruction()
 // This craziness is so that code_pos can be used in a multimap.
 // We use the node pointer as a < comparator.  Just something consistent but meaningless.
 
-//typedef std::list<scii>::iterator code_pos;
 //bool operator<(const code_pos &_Right, const code_pos &_Left)
 //{
 //	return _Right._Mynode() < _Left._Mynode();
 //}
 /* blackstar suggestion: use something different than std::list */
-bool operator < (const code_pos& lhs, const code_pos& rhs)
+bool operator<(const code_pos& lhs, const code_pos& rhs)
 {
 	auto it = lhs;
-	while (it != rhs && it != std::list<scii>::iterator{})
+	while (it != rhs)
 	{
-		++it;
+		if (++it == rhs) return true;   // lhs precedes rhs
+		if (it == lhs) break;           // safety check against infinite loop
 	}
-	return it == rhs;
+	return false;
 }

--- a/SCICompanionLib/Src/Dialogs/NewCompileDialog.cpp
+++ b/SCICompanionLib/Src/Dialogs/NewCompileDialog.cpp
@@ -22,7 +22,7 @@
 #include <filesystem>
 #include <regex>
 
-using namespace std::tr2::sys;
+using namespace std::filesystem;
 
 #define UWM_STARTCOMPILE (WM_APP + 0)
 

--- a/SCICompanionLib/Src/Dialogs/PicClipsDialog.cpp
+++ b/SCICompanionLib/Src/Dialogs/PicClipsDialog.cpp
@@ -22,7 +22,7 @@ GNU General Public License for more details.
 #include <regex>
 #include <format.h>
 
-using namespace std::tr2::sys;
+using namespace std::filesystem;
 using namespace fmt;
 using namespace std;
 

--- a/SCICompanionLib/Src/Docs/OutputRST.cpp
+++ b/SCICompanionLib/Src/Docs/OutputRST.cpp
@@ -21,7 +21,7 @@
 #include <regex>
 #include "StringUtil.h"
 
-using namespace std::tr2::sys;
+using namespace std::filesystem;
 
 // The code in this file is responsible for generating .rst documentation based on compiling the source code
 // and reading comments in the source dode.

--- a/SCICompanionLib/Src/MFCDocuments/NonViewHostDocument.cpp
+++ b/SCICompanionLib/Src/MFCDocuments/NonViewHostDocument.cpp
@@ -22,7 +22,11 @@
 // CNonViewHostDocument
 void CNonViewHostDocument::UpdateAllViewsAndNonViews(CView *pSender, LPARAM lHint, CObject *pObject)
 {
-	std::for_each(_nonViewClients.begin(), _nonViewClients.end(), std::bind2nd(_UpdateNonView(), pObject));
+	for (auto& nonViewClient : _nonViewClients)
+	{
+		nonViewClient->UpdateNonView(pObject);
+	}
+
 	__super::UpdateAllViews(pSender, lHint, pObject);
 }
 

--- a/SCICompanionLib/Src/MFCDocuments/ScriptDocument.cpp
+++ b/SCICompanionLib/Src/MFCDocuments/ScriptDocument.cpp
@@ -55,8 +55,12 @@ bool CompileLog::HasErrors()
 void CompileLog::CalculateErrors()
 {
 	// Calculate errors;
-	_cErrors += (int)count_if(_compileResults.begin(), _compileResults.end(), mem_fun_ref(&CompileResult::IsError));
-	_cWarnings += (int)count_if(_compileResults.begin(), _compileResults.end(), mem_fun_ref(&CompileResult::IsWarning));
+
+	for (auto& result : _compileResults)
+	{
+		if (result.IsError()) _cErrors++;
+		if (result.IsWarning()) _cWarnings++;
+	}
 }
 
 

--- a/SCICompanionLib/Src/MFCFrames/MainFrm.cpp
+++ b/SCICompanionLib/Src/MFCFrames/MainFrm.cpp
@@ -69,7 +69,7 @@
 #include <filesystem>
 #include <regex>
 
-using namespace std::tr2::sys;
+using namespace std::filesystem;
 
 #ifdef _DEBUG
 #define new DEBUG_NEW

--- a/SCICompanionLib/Src/Resources/Audio.cpp
+++ b/SCICompanionLib/Src/Resources/Audio.cpp
@@ -20,8 +20,6 @@
 #include "SoundUtil.h"
 #include "ResourceSourceFlags.h"
 
-using namespace std;
-
 // Speed work-around for VC 2013:
 // https://randomascii.wordpress.com/2013/11/24/stdmin-causing-three-times-slowdown-on-vc/
 template <class T>
@@ -200,7 +198,7 @@ void AudioReadFromHelper(ResourceEntity &resource, sci::istream &stream, const s
 		streamLipSync >> lipSyncMarker;
 		if (lipSyncMarker == 0x8e)
 		{
-			resource.AddComponent<SyncComponent>(make_unique<SyncComponent>());
+			resource.AddComponent<SyncComponent>(std::make_unique<SyncComponent>());
 			SyncReadFrom(resource, streamLipSync);
 		}
 		// else if it's not 0x8e, then it means this resource is kind of corrupt and *only* has raw lipsync data.
@@ -316,14 +314,14 @@ ResourceTraits waveAudioTraits =
 ResourceEntity *CreateAudioResource(SCIVersion version)
 {
 	std::unique_ptr<ResourceEntity> pResource = std::make_unique<ResourceEntity>(audioTraits);
-	pResource->AddComponent(move(make_unique<AudioComponent>()));
+	pResource->AddComponent(std::move(std::make_unique<AudioComponent>()));
 	return pResource.release();
 }
 
 ResourceEntity *CreateWaveAudioResource(SCIVersion version)
 {
 	std::unique_ptr<ResourceEntity> pResource = std::make_unique<ResourceEntity>(waveAudioTraits);
-	pResource->AddComponent(move(make_unique<AudioComponent>()));
+	pResource->AddComponent(std::move(std::make_unique<AudioComponent>()));
 	return pResource.release();
 }
 

--- a/SCICompanionLib/Src/Resources/AudioCacheResourceSource.cpp
+++ b/SCICompanionLib/Src/Resources/AudioCacheResourceSource.cpp
@@ -26,7 +26,7 @@
 #include "ResourceBlob.h"
 #include "ResourceMap.h"
 
-using namespace std::tr2;
+using namespace std::filesystem;
 
 // Tracks which cached audio files are currently up-to-date in the game's main resources.
 // Prevents us from having to rebuild resource.aud/sfx unnecessarily.
@@ -625,9 +625,9 @@ void RebuildFromAudioCacheFiles(SCIVersion version, const std::string &cacheSubf
 		entry.Offset = static_cast<uint32_t>(writeStream.tellp());
 		entry.SyncSize = 0;
 		// If it exists, open sync file and write it. Then take note of size. Then write audio.
-		if (sys::exists(sys::path(fullPathAudio)))
+		if (std::filesystem::exists(std::filesystem::path(fullPathAudio)))
 		{
-			if (!fullPathSync.empty() && sys::exists(sys::path(fullPathSync)))
+			if (!fullPathSync.empty() && std::filesystem::exists(std::filesystem::path(fullPathSync)))
 			{
 				std::ifstream syncFile;
 				syncFile.exceptions(std::ifstream::failbit | std::ifstream::badbit);

--- a/SCICompanionLib/Src/Resources/Message.cpp
+++ b/SCICompanionLib/Src/Resources/Message.cpp
@@ -19,8 +19,6 @@
 #include "NounsAndCases.h"
 #include "ResourceSourceFlags.h"
 
-using namespace std;
-
 void ResolveReferences(TextComponent &messageComponent)
 {
 	int messageCount = messageComponent.Texts.size();
@@ -309,32 +307,32 @@ std::vector<std::string> split(const std::string& value, char separator)
 
 void ExportMessageToFile(const TextComponent &message, const std::string &filename)
 {
-	ofstream file;
-	file.open(filename, ios_base::out | ios_base::trunc);
+	std::ofstream file;
+	file.open(filename, std::ios_base::out | std::ios_base::trunc);
 	if (file.is_open())
 	{
 		for (const auto &entry : message.Texts)
 		{
-			string firstPart = fmt::format("{0}\t{1}\t{2}\t{3}\t{4}\t", (int)entry.Noun, (int)entry.Verb, (int)entry.Condition, (int)entry.Sequence, (int)entry.Talker);
+			std::string firstPart = fmt::format("{0}\t{1}\t{2}\t{3}\t{4}\t", (int)entry.Noun, (int)entry.Verb, (int)entry.Condition, (int)entry.Sequence, (int)entry.Talker);
 			file << firstPart;
 			// Split by line to match SV.exe's output
-			vector<string> lines = split(entry.Text, '\n');
+			std::vector<std::string> lines = split(entry.Text, '\n');
 			int lineNumber = 0;
-			for (const string &line : lines)
+			for (const std::string &line : lines)
 			{
 				if (lineNumber > 0)
 				{
 					file << "\t\t\t\t\t"; // "Empty stuff" before next line (matches SV.exe's output)
 				}
 				file << line;
-				file << endl;
+				file << std::endl;
 				lineNumber++;
 			}
 		}
 	}
 }
 
-void ConcatWithTabs(const vector<string> &pieces, size_t pos, string &text)
+void ConcatWithTabs(const std::vector<std::string> &pieces, size_t pos, std::string &text)
 {
 	while (pos < pieces.size())
 	{
@@ -346,14 +344,14 @@ void ConcatWithTabs(const vector<string> &pieces, size_t pos, string &text)
 
 void ImportMessageFromFile(TextComponent &message, const std::string &filename)
 {
-	ifstream file;
-	file.open(filename, ios_base::in);
+	std::ifstream file;
+	file.open(filename, std::ios_base::in);
 	if (file.is_open())
 	{
-		string line;
+		std::string line;
 		while (std::getline(file, line))
 		{
-			vector<string> linePieces = split(line, '\t');
+			std::vector<std::string> linePieces = split(line, '\t');
 			if (linePieces.size() >= 6)
 			{
 				// If the first 5 are empty, then it's an extension of the previous line
@@ -390,13 +388,13 @@ bool ValidateMessage(const ResourceEntity &resource)
 {
 	// Check for duplicate tuples
 	const TextComponent &text = resource.GetComponent<TextComponent>();
-	unordered_map<uint32_t, const TextEntry *> tuples;
+	std::unordered_map<uint32_t, const TextEntry *> tuples;
 	for (const auto &entry : text.Texts)
 	{
 		uint32_t tuple = GetMessageTuple(entry);
 		if (tuples.find(tuple) != tuples.end())
 		{
-			string message = fmt::format("Entries must be distinct. The following entries have the same noun/verb/condition/sequence:\n{0}\n{1}",
+			std::string message = fmt::format("Entries must be distinct. The following entries have the same noun/verb/condition/sequence:\n{0}\n{1}",
 				entry.Text,
 				tuples[tuple]->Text
 				);
@@ -421,7 +419,7 @@ bool ValidateMessage(const ResourceEntity &resource)
 	{
 		if (!pair.second)
 		{
-			string message = fmt::format("The following mesaage: (noun:{0}, verb:{1}, cond:{2}) has a sequence that doesn't begin at 1. Save anyway?", (pair.first & 0xff), (pair.first >> 8) & 0xff, (pair.first >> 16) & 0xff);
+			std::string message = fmt::format("The following mesaage: (noun:{0}, verb:{1}, cond:{2}) has a sequence that doesn't begin at 1. Save anyway?", (pair.first & 0xff), (pair.first >> 8) & 0xff, (pair.first >> 16) & 0xff);
 			if (IDNO == AfxMessageBox(message.c_str(), MB_YESNO | MB_ICONWARNING))
 			{
 				return false;
@@ -457,7 +455,7 @@ ResourceTraits messageTraits =
 ResourceEntity *CreateMessageResource(SCIVersion version)
 {
 	std::unique_ptr<ResourceEntity> pResource = std::make_unique<ResourceEntity>(messageTraits);
-	pResource->AddComponent(move(make_unique<TextComponent>()));
+	pResource->AddComponent(std::move(std::make_unique<TextComponent>()));
 	switch (version.MessageMapSource)
 	{
 		case MessageMapSource::Included:

--- a/SCICompanionLib/Src/Resources/ResourceMap.cpp
+++ b/SCICompanionLib/Src/Resources/ResourceMap.cpp
@@ -388,9 +388,11 @@ void CResourceMap::AbortPostBuildThread()
 void CResourceMap::PokeResourceMapReloaded()
 {
 	// Refresh everything.
-	for_each(_syncs.begin(), _syncs.end(), bind2nd(mem_fun(&IResourceMapEvents::OnResourceMapReloaded), false));
+	for (auto& sync : _syncs)
+	{
+		sync->OnResourceMapReloaded(false);
+	}
 }
-
 void CResourceMap::StartDebuggerThread(int optionalResourceNumber)
 {
 	AbortDebuggerThread();
@@ -661,12 +663,19 @@ void CResourceMap::_SniffSCIVersion()
 
 void CResourceMap::NotifyToRegenerateImages()
 {
-	for_each(_syncs.begin(), _syncs.end(), mem_fun(&IResourceMapEvents::OnImagesInvalidated));
+	for (auto& sync : _syncs)
+	{
+		sync->OnImagesInvalidated();
+	}
 }
 
 void CResourceMap::NotifyToReloadResourceType(ResourceType iType)
 {
-	for_each(_syncs.begin(), _syncs.end(), bind2nd(mem_fun(&IResourceMapEvents::OnResourceTypeReloaded), iType));
+	for (auto& sync : _syncs)
+	{
+		sync->OnResourceTypeReloaded(iType);
+	}
+
 	if (iType == ResourceType::Palette)
 	{
 		_paletteListNeedsUpdate = true;
@@ -726,7 +735,11 @@ void CResourceMap::DeleteResource(const ResourceBlob *pData)
 		_globalCompiledScriptLookups.reset(nullptr);
 	}
 
-	for_each(_syncs.begin(), _syncs.end(), bind2nd(mem_fun(&IResourceMapEvents::OnResourceDeleted), pData));
+	for (auto& sync : _syncs)
+	{
+		sync->OnResourceDeleted(pData);
+	}
+
 	if (pData->GetType() == ResourceType::Palette)
 	{
 		_paletteListNeedsUpdate = true;
@@ -1278,7 +1291,10 @@ void CResourceMap::SetGameFolder(const string &gameFolder)
 			_SniffSCIVersion();
 
 			// Send initial load notification
-			for_each(_syncs.begin(), _syncs.end(), bind2nd(mem_fun(&IResourceMapEvents::OnResourceMapReloaded), true));
+			for (auto& sync : _syncs)
+			{
+				sync->OnResourceMapReloaded(true);
+			}
 
 			_paletteListNeedsUpdate = true;
 		}

--- a/SCICompanionLib/Src/Resources/Vocab000.h
+++ b/SCICompanionLib/Src/Resources/Vocab000.h
@@ -64,7 +64,7 @@ public:
 
 	typedef DWORD WordGroup;
 
-	typedef std::unordered_map<std::string, WordGroup> word2group_map;
+	typedef std::map<std::string, WordGroup> word2group_map;
 	typedef std::unordered_map<WordGroup, std::string> group2words_map;
 	typedef std::unordered_map<WordGroup, WordClass> group2class_map;
 

--- a/SCICompanionLib/Src/Util/NonViewClient.h
+++ b/SCICompanionLib/Src/Util/NonViewClient.h
@@ -33,12 +33,3 @@ public:
 	virtual void AddNonViewClient(INonViewClient *pClient) = 0;
 	virtual void UpdateAllViewsAndNonViews(CView *pSender, LPARAM lHint, CObject *pObject = NULL) = 0;
 };
-
-// stl helper
-struct _UpdateNonView : public std::binary_function<INonViewClient*, CObject*, void>
-{
-	void operator()(INonViewClient *pClient, CObject *pObjec) const
-	{
-		pClient->UpdateNonView(pObjec);
-	}
-};

--- a/SCICompanionLib/Src/Util/ScriptConvert.cpp
+++ b/SCICompanionLib/Src/Util/ScriptConvert.cpp
@@ -27,7 +27,7 @@
 
 using namespace sci;
 using namespace std;
-using namespace std::tr2::sys;
+using namespace std::filesystem;
 
 
 

--- a/SCICompanionLib/Src/Util/StringUtil.h
+++ b/SCICompanionLib/Src/Util/StringUtil.h
@@ -20,13 +20,13 @@
 
 // trim from start
 static inline std::string &ltrim(std::string &s) {
-	s.erase(s.begin(), std::find_if(s.begin(), s.end(), std::not1(std::ptr_fun<int, int>(std::isspace))));
+	s.erase(s.begin(), std::find_if(s.begin(), s.end(), std::not_fn(isspace)));
 	return s;
 }
 
 // trim from end
 static inline std::string &rtrim(std::string &s) {
-	s.erase(std::find_if(s.rbegin(), s.rend(), std::not1(std::ptr_fun<int, int>(std::isspace))).base(), s.end());
+	s.erase(std::find_if(s.rbegin(), s.rend(), std::not_fn(isspace)).base(), s.end());
 	return s;
 }
 

--- a/SCICompanionLib/Src/Util/util.cpp
+++ b/SCICompanionLib/Src/Util/util.cpp
@@ -19,7 +19,7 @@
 #include "TlHelp32.h"
 #include <filesystem>
 
-using namespace std::tr2::sys;
+using namespace std::filesystem;
 using namespace fmt;
 
 __declspec(dllexport) void _cdecl DummyFunctionSoWeBuildALib()


### PR DESCRIPTION
So I've managed to get this thing running again on VS2022/C++17.

Adressed most of the deprecated stuff (except for the define I had to enable to get around the string issues)
The list iterator is absolutely one of the most evil things I've ever seen, I recommend creating a different container for this.
All the unary_function inheritence is going, I am unsure if all of this will still work (I just ran the .exe and it can load a game) but it's most likely better to replace all the usages of those with a lambda.

Left a lot of code in comment with marker "blackstar"